### PR TITLE
Fix build-dev which was a correct command

### DIFF
--- a/src/initialize.rb
+++ b/src/initialize.rb
@@ -310,8 +310,9 @@ def prompt
     when /about (.*)/
       then Package.get_info($1)
 
-    when /build\s*(.*)/ then
-      f = $1 == "dev"
+    when /build(\s.*)?$/ then
+      Console.alert $1.to_s.strip == "dev"
+      f = $1.to_s.strip == "dev"
       Builder.stack_error = []
       Builder.schema_final = []
       Builder.to_install.each do |name, type|


### PR DESCRIPTION
I had a problem. I though `build-dev` was a valid command but it was just building normal. This fix allow `build` and `build dev` to work but not wrong command as `build-dev`.
